### PR TITLE
test: Force 400 status code on root-level handler of calculator test

### DIFF
--- a/services/calculator/src/__tests__/express.store.errors.spec.ts
+++ b/services/calculator/src/__tests__/express.store.errors.spec.ts
@@ -19,8 +19,10 @@ describe("express app", () => {
         .object({ test: joi.string().required() })
         .required()
         .validate({});
-      if (error)
+      if (error) {
+        res.status(400);
         throw new ValidationError(error.details.flatMap((d) => d.message));
+      }
       res.send("Query results");
     });
     await exapp.listen(false, port);


### PR DESCRIPTION
## Why?

We had broken tests that were related to the HTTP status code returned by the calculator service.

Since its tests set up a new app and manually creates a `/query` route, this route doesn't have the same error handlers that other routes have (the ones used for commands, for example).

## What?

This PR enforces the root-level `/query` handler in the test to send a 400 status code in case of a Joi validation error. This way we still test the functionality of a validation error being returned.
